### PR TITLE
New/async.promise.hack

### DIFF
--- a/.github/workflows/Linux-Vim-neovim.yml
+++ b/.github/workflows/Linux-Vim-neovim.yml
@@ -22,7 +22,7 @@ jobs:
           - vim-v8.2
           - vim-v8.1
           - neovim-nightly
-          - neovim-nightly
+          - neovim-v0.4.3
         include:
           - name: vim-v8.2
             vim-url: v8.2.0182/GVim-v8.2.0182.glibc2.15-x86_64.AppImage

--- a/autoload/vital/__luv__/Async/Promise/Hack.vim
+++ b/autoload/vital/__luv__/Async/Promise/Hack.vim
@@ -1,28 +1,80 @@
 
-function! s:_vital_loaded(V) abort
-  let s:Promise = a:V.import('Async.Promise')
-
-  " Just xtend Async.Promise
-  for key in keys(s:Promise)
-    if !has_key(s:, key)
-      let s:[key] = s:Promise[key]
-    endif
-  endfor
-endfunction
 function! s:_vital_depends() abort
   return [
-        \ 'Async.Promise',
-        \]
+        \   'Async.Promise',
+        \ ]
+endfunction
+function! s:_vital_loaded(V) abort
+  let s:Promise = a:V.import('Async.Promise')
 endfunction
 
 function! s:new(resolver, ...)
   let timeout = a:0 ? a:1 : 5000
-  let promise = s:Promise.new(resolver)
+  let promise = s:Promise.new(a:resolver)
   if s:debug
     call timer_start(timeout, {-> promise.catch(s:err_handler)})
   endif
   return promise
 endfunction
+
+function! s:resolve(...)
+  let value = a:0 ? a:1 : v:null
+  let timeout = a:0 > 1 ? a:2 : 5000
+  let promise = s:Promise.resolve(value)
+  if s:debug
+    call timer_start(timeout, {-> promise.catch(s:err_handler)})
+  endif
+  return promise
+endfunction
+
+function! s:reject(...)
+  let value = a:0 ? a:1 : v:null
+  let timeout = a:0 > 1 ? a:2 : 5000
+  let promise = s:Promise.reject(value)
+  if s:debug
+    call timer_start(timeout, {-> promise.catch(s:err_handler)})
+  endif
+  return promise
+endfunction
+
+function! s:all(promises, ...)
+  let timeout = a:0 ? a:1 : 5000
+  let promise = s:Promise.all(a:promises)
+  if s:debug
+    call timer_start(timeout, {-> promise.catch(s:err_handler)})
+  endif
+  return promise
+endfunction
+
+
+" XXX : If vital supports `extend` feature,
+"       below must be replaced to that.
+function! s:race(promises, ...)
+  let value = a:0 ? a:1 : v:null
+  let timeout = a:0 > 1 ? a:2 : 5000
+  let promise = s:Promise.race(a:promises)
+  if s:debug
+    call timer_start(timeout, {-> promise.catch(s:err_handler)})
+  endif
+  return promise
+endfunction
+
+function! s:is_available(...) abort
+  return call(Promise.is_available, a:000)
+endfunction
+
+function! s:is_promise(...) abort
+  return call(Promise.is_promise, a:000)
+endfunction
+
+function! s:wait(...) abort
+  return call(Promise.wait, a:000)
+endfunction
+
+function! s:noop(...) abort
+  return call(Promise.wait, a:000)
+endfunction
+
 
 function! s:set_debug(debug)
   let s:debug = a:debug
@@ -71,4 +123,3 @@ function! s:_default_err_handler(ex) abort
 endfunction
 
 let s:err_handler = function('s:_default_err_handler')
-

--- a/autoload/vital/__luv__/Async/Promise/Hack.vim
+++ b/autoload/vital/__luv__/Async/Promise/Hack.vim
@@ -1,8 +1,8 @@
 
 function! s:_vital_loaded(V) abort
-  let s:Pormise = a:V.import('Async.Promise')
+  let s:Promise = a:V.import('Async.Promise')
 
-  " Just extend Async.Promise
+  " Just xtend Async.Promise
   for key in keys(s:Promise)
     if !has_key(s:, key)
       let s:[key] = s:Promise[key]

--- a/autoload/vital/__luv__/Async/Promise/Hack.vim
+++ b/autoload/vital/__luv__/Async/Promise/Hack.vim
@@ -1,0 +1,67 @@
+
+function! s:_vital_loaded(V) abort
+  let s:Pormise = a:V.import('Promise')
+endfunction
+function! s:_vital_depends() abort
+  return [
+        \ 'Promise',
+        \]
+endfunction
+
+function! s:new(resolver, ...)
+  let timeout = a:0 ? a:1 : 5000
+  let promise = s:Promise.new(resolver)
+  if s:debug
+    call timer_start(timeout, {-> promise.catch(s:err_handler)})
+  endif
+  return promise
+endfunction
+
+function! s:set_debug(debug)
+  let s:debug = a:debug
+endfunction
+let s:debug = 0
+
+function! s:set_error_handler(err_handler)
+  if err_handler is v:t_func
+    let s:err_handler = a:err_handler
+  else
+    let s:err_handler = function('s:_default_err_handler')
+  endif
+endfunction
+
+function! s:_default_err_handler(ex) abort
+  if type(a:ex) == v:t_dict && has_key(a:ex, 'throwpoint')
+    let pat = '\C^\(.*\), line \(\d\+\)$'
+    let throwpoint = a:ex.throwpoint
+    let line = v:null
+    if throwpoint =~# pat
+      let groups = matchlist(a:ex.throwpoint, pat)
+      let throwpoint = groups[1] . ':'
+      let line = 'line ' . groups[2] . ':'
+    endif
+    echohl ErrorMsg
+    echom 'Error detected while processing ' . throwpoint
+    echohl None
+    if line isnot v:null
+      echom line
+    endif
+    if has_key(a:ex, 'exception')
+      echohl ErrorMsg
+      echom "<Promise Uncaught Exception> " . a:ex.exception
+      if len(keys(a:ex)) > 2
+        echom "<Promise Uncaught> " . string(a:ex)
+      endif
+      echohl None
+    else
+      echom "<Promise Uncaught> " . string(a:ex)
+    endif
+  else
+    echohl ErrorMsg
+    echom '<Promise Uncaught>' . string(a:ex)
+    echohl None
+  endif
+endfunction
+
+let s:err_handler = function('s:_default_err_handler')
+

--- a/autoload/vital/__luv__/Async/Promise/Hack.vim
+++ b/autoload/vital/__luv__/Async/Promise/Hack.vim
@@ -89,6 +89,14 @@ function! s:set_error_handler(err_handler)
   endif
 endfunction
 
+function! s:get_error_handler()
+  return s:err_handler
+endfunction
+
+function! s:get_default_error_handler()
+  return function('s:_default_err_handler')
+endfunction
+
 function! s:_default_err_handler(ex) abort
   if type(a:ex) == v:t_dict && has_key(a:ex, 'throwpoint')
     let pat = '\C^\(.*\), line \(\d\+\)$'
@@ -98,26 +106,28 @@ function! s:_default_err_handler(ex) abort
       let groups = matchlist(a:ex.throwpoint, pat)
       let throwpoint = groups[1] . ':'
       let line = 'line ' . groups[2] . ':'
+    else
+      let throwpoint .=  ':'
     endif
     echohl ErrorMsg
-    echom 'Error detected while processing ' . throwpoint
+    echomsg 'Error detected while processing ' . throwpoint
     echohl None
     if line isnot v:null
-      echom line
+      echomsg line
     endif
     if has_key(a:ex, 'exception')
       echohl ErrorMsg
-      echom "<Promise Uncaught Exception> " . a:ex.exception
+      echomsg "<Promise Uncaught Exception> " . a:ex.exception
       if len(keys(a:ex)) > 2
-        echom "<Promise Uncaught> " . string(a:ex)
+        echomsg "<Promise Uncaught> " . string(a:ex)
       endif
       echohl None
     else
-      echom "<Promise Uncaught> " . string(a:ex)
+      echomsg "<Promise Uncaught> " . string(a:ex)
     endif
   else
     echohl ErrorMsg
-    echom '<Promise Uncaught>' . string(a:ex)
+    echomsg '<Promise Uncaught>' . string(a:ex)
     echohl None
   endif
 endfunction

--- a/autoload/vital/__luv__/Async/Promise/Hack.vim
+++ b/autoload/vital/__luv__/Async/Promise/Hack.vim
@@ -1,10 +1,17 @@
 
 function! s:_vital_loaded(V) abort
-  let s:Pormise = a:V.import('Promise')
+  let s:Pormise = a:V.import('Async.Promise')
+
+  " Just extend Async.Promise
+  for key in keys(s:Promise)
+    if !has_key(s:, key)
+      let s:[key] = s:Promise[key]
+    endif
+  endfor
 endfunction
 function! s:_vital_depends() abort
   return [
-        \ 'Promise',
+        \ 'Async.Promise',
         \]
 endfunction
 

--- a/autoload/vital/__luv__/Async/Promise/Hack.vim
+++ b/autoload/vital/__luv__/Async/Promise/Hack.vim
@@ -118,7 +118,7 @@ function! s:_hack_promise(promise) abort
   let Orig_then = a:promise.then
   function! a:promise.then(...) abort closure
     let promise = call(Orig_then, a:000)
-    if s:debug && get(a:000, 0, v:null) isnot v:null
+    if s:debug
       let promise = s:_hack_promise(promise)
     endif
     if exists('timer_id') && get(a:000, 1, v:null) isnot v:null

--- a/doc/Vital/Async/Promise/Hack.txt
+++ b/doc/Vital/Async/Promise/Hack.txt
@@ -37,6 +37,14 @@ set_err_handler({handler})
 	error handler. The default handler is showing the exception in
 	|:echomsg|.
 
+			*Vital.Async.Promise.Hack.get_err_handler()*
+get_err_handler()
+	Get the handler that is set now.
+
+			*Vital.Async.Promise.Hack.get_default_err_handler()*
+get_default_err_handler()
+	Get the default handler. Useful for setting by yourself.
+
 			*Vital.Async.Promise.Hack.new()*
 			*Vital.Async.Promise.Hack.resolve()*
 			*Vital.Async.Promise.Hack.reject()*
@@ -48,8 +56,8 @@ reject([{value} [, {timeout} = 5000]])
 all({promises} [, {timeout} = 5000])
 race({promises} [, {timeout} = 5000])
 	Alternatives for |Vital.Async.Promise-functions|.
-	After {timeout} ms, this register
-	|Vital.Async.Promise-Promise.catch()| of the instance returned.
+	After {timeout} ms, this register the error handler by 
+	|Vital.Async.Promise-Promise.catch()|.
 
 			*Vital.Async.Promise.Hack.is_available()*
 			*Vital.Async.Promise.Hack.is_promise()*

--- a/doc/Vital/Async/Promise/Hack.txt
+++ b/doc/Vital/Async/Promise/Hack.txt
@@ -43,11 +43,16 @@ set_debug({debug})
     call Promise.set_debug(1)
 <
 
+			*Vital.Async.Promise.Hack.get_err_handler()*
+get_err_handler()
+	Get the handler that is set now.
+	The default handler is showing the exception in |:echomsg| like with
+	the style that Vim show in English.
+
 			*Vital.Async.Promise.Hack.set_err_handler()*
 set_err_handler({handler})
 	Set the handler for error handling. Set |v:null| to use the default
-	error handler. The default handler is showing the exception in
-	|:echomsg|.
+	error handler.
 
 			*Vital.Async.Promise.Hack.set_timeout()*
 set_timeout({timeout})
@@ -56,10 +61,6 @@ set_timeout({timeout})
 Ex:>
 	call Promise.set_timeout(1)
 <
-
-			*Vital.Async.Promise.Hack.get_err_handler()*
-get_err_handler()
-	Get the handler that is set now.
 
 			*Vital.Async.Promise.Hack.get_default_err_handler()*
 get_default_err_handler()
@@ -75,8 +76,8 @@ Ex:>
 			*Vital.Async.Promise.Hack.all()*
 			*Vital.Async.Promise.Hack.race()*
 new({executor})
-resolve([{value})
-reject([{value})
+resolve([{value}])
+reject([{value}])
 all({promises})
 race({promises})
 	Alternatives for |Vital.Async.Promise-functions|.
@@ -86,6 +87,11 @@ race({promises})
 			*Vital.Async.Promise.Hack.is_available()*
 			*Vital.Async.Promise.Hack.is_promise()*
 	Copies from |Vital.Async.Promise-functions|.
+
+
+	Note that you should be careful, if your handler failed, you will miss
+	the error again against the purpose of this plugin. Recommended to use
+	well tested handers.
 
 ==============================================================================
 vim:tw=78:ts=8:noet:ft=help:norl

--- a/doc/Vital/Async/Promise/Hack.txt
+++ b/doc/Vital/Async/Promise/Hack.txt
@@ -18,12 +18,19 @@ INTRODUCTION				*Vital.Async.Promise.Hack-introduction*
 
 *Vital.Async.Promise.Hack* is the lazy hack to ease debugging
 |Vital.Async.Promise|. Sometimes we forgot to register the catch.
-The features are off by default and you should enable by
-|Vital.Async.Promise.Hack.set_debug()|.
+The features are off by default and you should enable by yourself.
+Ex:>
+    call Promise.set_debug(1)
+<
 
 This is the one-liner Ex command to replace your imports.
 >
   :vim /#import('Async.Promise')/ `find . -name "*.vim" -a -not -path "*autoload/vital*"` | cdo s/#import('Async.Promise')/#import('Async.Promise.Hack')/g | up
+<
+
+This is the one for revert.
+>
+  :vim /#import('Async.Promise.Hack')/ `find . -name "*.vim" -a -not -path "*autoload/vital*"` | cdo s/#import('Async.Promise.Hack')/#import('Async.Promise')/g | up
 <
 
 ==============================================================================
@@ -32,6 +39,9 @@ FUNCTIONS 				*Vital.Async.Promise.Hack-functions*
 			*Vital.Async.Promise.Hack.set_debug()*
 set_debug({debug})
 	Set truthy value to enable features of this plugin.
+>
+    call Promise.set_debug(1)
+<
 
 			*Vital.Async.Promise.Hack.set_err_handler()*
 set_err_handler({handler})
@@ -43,6 +53,9 @@ set_err_handler({handler})
 set_timeout({timeout})
 	Set the default timeout [ms] to provide to |timer_start()|. The
 	default timeout is set to 5000 ms.
+Ex:>
+	call Promise.set_timeout(1)
+<
 
 			*Vital.Async.Promise.Hack.get_err_handler()*
 get_err_handler()
@@ -51,17 +64,21 @@ get_err_handler()
 			*Vital.Async.Promise.Hack.get_default_err_handler()*
 get_default_err_handler()
 	Get the default handler. Useful for setting by yourself.
+Ex:>
+	let E = PromiseHack.get_default_err_handler()
+	call my_promise.catch(E)
+<
 
 			*Vital.Async.Promise.Hack.new()*
 			*Vital.Async.Promise.Hack.resolve()*
 			*Vital.Async.Promise.Hack.reject()*
 			*Vital.Async.Promise.Hack.all()*
 			*Vital.Async.Promise.Hack.race()*
-new({executor} [, {timeout} = 5000])
-resolve([{value} [, {timeout} = 5000]])
-reject([{value} [, {timeout} = 5000]])
-all({promises} [, {timeout} = 5000])
-race({promises} [, {timeout} = 5000])
+new({executor})
+resolve([{value})
+reject([{value})
+all({promises})
+race({promises})
 	Alternatives for |Vital.Async.Promise-functions|.
 	After {timeout} ms, this register the error handler by 
 	|Vital.Async.Promise-Promise.catch()|.

--- a/doc/Vital/Async/Promise/Hack.txt
+++ b/doc/Vital/Async/Promise/Hack.txt
@@ -10,7 +10,7 @@ Support: neovim 0.4.3 and Above
 CONTENTS				*Vital.Async.Promise.Hack-contents*
 
 INTRODUCTION			|Vital.Async.Promise.Hack-introduction|
-FUNCTION			|Vital.Async.Promise.Hack-function|
+FUNCTIONS			|Vital.Async.Promise.Hack-functions|
 
 
 ==============================================================================
@@ -25,13 +25,7 @@ This is the one-liner Ex command to replace your imports.
 <
 
 ==============================================================================
-FUNCTION 				*Vital.Async.Promise.Hack-function*
-
-			*Vital.Async.Promise.Hack.new()*
-new({executor} [, {timeout} = 5000] )
-	Alternative for |Vital.Async.Promise.new()|.
-	After {timeout} ms, this register
-	|Vital.Async.Promise-Promise.catch()| of the instance returned.
+FUNCTIONS 				*Vital.Async.Promise.Hack-functions*
 
 			*Vital.Async.Promise.Hack.set_debug()*
 set_debug({debug})
@@ -42,6 +36,24 @@ set_err_handler({handler})
 	Set the handler for error handling. Set |v:null| to use the default
 	error handler. The default handler is showing the exception in
 	|:echomsg|.
+
+			*Vital.Async.Promise.Hack.new()*
+			*Vital.Async.Promise.Hack.resolve()*
+			*Vital.Async.Promise.Hack.reject()*
+			*Vital.Async.Promise.Hack.all()*
+			*Vital.Async.Promise.Hack.race()*
+new({executor} [, {timeout} = 5000])
+resolve([{value} [, {timeout} = 5000]])
+reject([{value} [, {timeout} = 5000]])
+all({promises} [, {timeout} = 5000])
+race({promises} [, {timeout} = 5000])
+	Alternatives for |Vital.Async.Promise-functions|.
+	After {timeout} ms, this register
+	|Vital.Async.Promise-Promise.catch()| of the instance returned.
+
+			*Vital.Async.Promise.Hack.is_available()*
+			*Vital.Async.Promise.Hack.is_promise()*
+	Copies from |Vital.Async.Promise-functions|.
 
 ==============================================================================
 vim:tw=78:ts=8:noet:ft=help:norl

--- a/doc/Vital/Async/Promise/Hack.txt
+++ b/doc/Vital/Async/Promise/Hack.txt
@@ -1,0 +1,47 @@
+*Vital.Async.Promise.Hack.txt*	Default error handling to ease debugging.
+
+Author : Luma <tomorinao.info@gmail.com>
+License: The Unlicense
+Support: Vim 8.1 and Above
+Support: neovim 0.4.3 and Above
+
+
+==============================================================================
+CONTENTS				*Vital.Async.Promise.Hack-contents*
+
+INTRODUCTION			|Vital.Async.Promise.Hack-introduction|
+FUNCTION			|Vital.Async.Promise.Hack-function|
+
+
+==============================================================================
+INTRODUCTION				*Vital.Async.Promise.Hack-introduction*
+
+*Vital.Async.Promise.Hack* is the lazy hack to ease debugging
+|Vital.Async.Promise|. Sometimes we forgot to register the catch.
+
+This is the one-liner Ex command to replace your imports.
+>
+  :vim /#import('Async.Promise')/ `find . -name "*.vim" -a -not -path "*autoload/vital*"` | cdo s/#import('Async.Promise')/#import('Async.Promise.Hack')/g | up
+<
+
+==============================================================================
+FUNCTION 				*Vital.Async.Promise.Hack-function*
+
+			*Vital.Async.Promise.Hack.new()*
+new({executor} [, {timeout} = 5000] )
+	Alternative for |Vital.Async.Promise.new()|.
+	After {timeout} ms, this register
+	|Vital.Async.Promise-Promise.catch()| of the instance returned.
+
+			*Vital.Async.Promise.Hack.set_debug()*
+set_debug({debug})
+	Set truthy value to enable features of this plugin.
+
+			*Vital.Async.Promise.Hack.set_err_handler()*
+set_err_handler({handler})
+	Set the handler for error handling. Set |v:null| to use the default
+	error handler. The default handler is showing the exception in
+	|:echomsg|.
+
+==============================================================================
+vim:tw=78:ts=8:noet:ft=help:norl

--- a/doc/Vital/Async/Promise/Hack.txt
+++ b/doc/Vital/Async/Promise/Hack.txt
@@ -18,6 +18,8 @@ INTRODUCTION				*Vital.Async.Promise.Hack-introduction*
 
 *Vital.Async.Promise.Hack* is the lazy hack to ease debugging
 |Vital.Async.Promise|. Sometimes we forgot to register the catch.
+The features are off by default and you should enable by
+|Vital.Async.Promise.Hack.set_debug()|.
 
 This is the one-liner Ex command to replace your imports.
 >
@@ -36,6 +38,11 @@ set_err_handler({handler})
 	Set the handler for error handling. Set |v:null| to use the default
 	error handler. The default handler is showing the exception in
 	|:echomsg|.
+
+			*Vital.Async.Promise.Hack.set_timeout()*
+set_timeout({timeout})
+	Set the default timeout [ms] to provide to |timer_start()|. The
+	default timeout is set to 5000 ms.
 
 			*Vital.Async.Promise.Hack.get_err_handler()*
 get_err_handler()

--- a/test/unit/Async/Promise/Hack.vimspec
+++ b/test/unit/Async/Promise/Hack.vimspec
@@ -1,0 +1,52 @@
+
+Describe Async.Promise.Hack
+  Before all
+    let Promise0 = vital#vital#import('Async.Promise')
+    let Promise = vital#vital#import('Async.Promise.Hack')
+    call Promise.set_debug(1)
+  End
+
+  Describe .new()
+    It creates promise instance
+      redir => mes
+        call Promise.new({resolve, reject -> reject('reject from new')}, 100)
+        silent! sleep 1s
+      redir END
+      Assert Match(mes, '\CError detected while processing')
+      Assert Match(mes, '\creject from new')
+    End
+  End
+
+  Describe .resolve()
+    It creates promise instance
+      redir => mes
+        call Promise.resolve('foo', 100)
+              \.then({->execute('_bar')})
+        sleep 1s
+      redir END
+      Assert Match(mes, '\CError detected while processing')
+      Assert Match(mes, '\c_bar')
+    End
+  End
+
+  Describe .reject()
+    It creates promise instance
+      redir => mes
+        call Promise.reject('foo', 100)
+        sleep 1s
+      redir END
+      Assert Match(mes, '\CError detected while processing')
+      Assert Match(mes, '\cfoo')
+    End
+  End
+
+  It extends promise features
+    for key in keys(Promise0)
+      if type(Promise0[key]) == v:t_func
+        call themis#log(key)
+        Assert True(has_key(Promise, key))
+      endif
+    endfor
+  End
+End
+

--- a/test/unit/Async/Promise/Hack.vimspec
+++ b/test/unit/Async/Promise/Hack.vimspec
@@ -7,36 +7,46 @@ Describe Async.Promise.Hack
   End
 
   Describe .new()
-    It creates promise instance
+    It echos throwed error
       redir => mes
-        call Promise.new({resolve, reject -> reject('reject from new')}, 100)
-        silent! sleep 1s
+        call Promise.new({resolve, reject -> [execute("throw 'error from throw'"), 0][-1]}, 10)
+        sleep 200m
       redir END
       Assert Match(mes, '\CError detected while processing')
+      Assert Match(mes, '\cerror from throw')
+    End
+    It echos rejected error
+      redir => mes
+        call Promise.new({resolve, reject -> [reject('reject from new'), 0][-1]}, 10)
+        sleep 200m
+      redir END
       Assert Match(mes, '\creject from new')
     End
   End
 
   Describe .resolve()
-    It creates promise instance
+    It echos throwed error of invalid Ex command
+      function! s:_test() abort
+        _bar
+      endfunction
       redir => mes
-        call Promise.resolve('foo', 100)
-              \.then({->execute('_bar')})
-        sleep 1s
+        call Promise.resolve('foo', 10)
+              \.then({val -> s:_test()})
+              \.catch(Promise.get_default_error_handler())
+        sleep 200m
       redir END
       Assert Match(mes, '\CError detected while processing')
-      Assert Match(mes, '\c_bar')
+      Assert Match(mes, '\C_bar')
     End
   End
 
   Describe .reject()
-    It creates promise instance
+    It echos rejected error
       redir => mes
-        call Promise.reject('foo', 100)
-        sleep 1s
+        call Promise.reject('reject from Promise.reject()', 10)
+        sleep 200m
       redir END
-      Assert Match(mes, '\CError detected while processing')
-      Assert Match(mes, '\cfoo')
+      Assert Match(mes, '\Creject from Promise.reject()')
     End
   End
 

--- a/test/unit/Async/Promise/Hack.vimspec
+++ b/test/unit/Async/Promise/Hack.vimspec
@@ -3,13 +3,15 @@ Describe Async.Promise.Hack
   Before all
     let Promise0 = vital#vital#import('Async.Promise')
     let Promise = vital#vital#import('Async.Promise.Hack')
+    let E = Promise.get_default_error_handler()
     call Promise.set_debug(1)
+    call Promise.set_timeout(10)
   End
 
   Describe .new()
     It echos throwed error
       redir => mes
-        call Promise.new({resolve, reject -> [execute("throw 'error from throw'"), 0][-1]}, 10)
+        call Promise.new({resolve, reject -> [execute("throw 'error from throw'"), 0][-1]})
         sleep 200m
       redir END
       Assert Match(mes, '\CError detected while processing')
@@ -17,7 +19,7 @@ Describe Async.Promise.Hack
     End
     It echos rejected error
       redir => mes
-        call Promise.new({resolve, reject -> [reject('reject from new'), 0][-1]}, 10)
+        call Promise.new({resolve, reject -> [reject('reject from new'), 0][-1]})
         sleep 200m
       redir END
       Assert Match(mes, '\creject from new')
@@ -25,14 +27,13 @@ Describe Async.Promise.Hack
   End
 
   Describe .resolve()
-    It echos throwed error of invalid Ex command
+    It hacks .then()
       function! s:_test() abort
         _bar
       endfunction
       redir => mes
-        call Promise.resolve('foo', 10)
+        call Promise.resolve('foo')
               \.then({val -> s:_test()})
-              \.catch(Promise.get_default_error_handler())
         sleep 200m
       redir END
       Assert Match(mes, '\CError detected while processing')
@@ -43,12 +44,26 @@ Describe Async.Promise.Hack
   Describe .reject()
     It echos rejected error
       redir => mes
-        call Promise.reject('reject from Promise.reject()', 10)
+        call Promise.reject('reject from Promise.reject()')
         sleep 200m
       redir END
       Assert Match(mes, '\Creject from Promise.reject()')
     End
   End
+
+  Describe .get_default_error_handler()
+    It provides useful error handler
+      redir => mes
+        call Promise0.resolve('foo')
+              \.then({val -> execute('_bar')})
+              \.catch(E)
+        sleep 200m
+      redir END
+      Assert Match(mes, '\CError detected while processing')
+      Assert Match(mes, '\C_bar')
+    End
+  End
+
 
   It extends promise features
     for key in keys(Promise0)

--- a/test/unit/Async/Promise/Hack.vimspec
+++ b/test/unit/Async/Promise/Hack.vimspec
@@ -5,7 +5,7 @@ Describe Async.Promise.Hack
     let Promise = vital#vital#import('Async.Promise.Hack')
     let E = Promise.get_default_error_handler()
     call Promise.set_debug(1)
-    call Promise.set_timeout(10)
+    call Promise.set_timeout(1)
   End
 
   Describe .new()
@@ -16,6 +16,8 @@ Describe Async.Promise.Hack
       redir END
       Assert Match(mes, '\CError detected while processing')
       Assert Match(mes, '\cerror from throw')
+      " Check called just once
+      Assert NotMatch(mes, repeat('\CError detected while processing.*', 2))
     End
     It echos rejected error
       redir => mes
@@ -23,6 +25,19 @@ Describe Async.Promise.Hack
         sleep 200m
       redir END
       Assert Match(mes, '\creject from new')
+      " Check called just once
+      Assert NotMatch(mes, repeat('\creject from new.*', 2))
+    End
+    It not block .catch by user
+      let handled_myself = 0
+      redir => mes
+        call Promise.new({resolve, reject -> [execute("throw 'error from throw'"), 0][-1]})
+              \.catch({-> [handled_myself, execute('let handled_myself = 1')]})
+        sleep 200m
+      redir END
+      Assert NotMatch(mes, '\CError detected while processing')
+      Assert NotMatch(mes, '\cerror from throw')
+      Assert Equals(handled_myself, 1)
     End
   End
 
@@ -38,6 +53,8 @@ Describe Async.Promise.Hack
       redir END
       Assert Match(mes, '\CError detected while processing')
       Assert Match(mes, '\C_bar')
+      " Check called just once
+      Assert NotMatch(mes, repeat('\CError detected while processing.*', 2))
     End
   End
 
@@ -48,6 +65,8 @@ Describe Async.Promise.Hack
         sleep 200m
       redir END
       Assert Match(mes, '\Creject from Promise.reject()')
+      " Check called just once
+      Assert NotMatch(mes, repeat('\Creject from Promise.reject().*', 2))
     End
   End
 
@@ -61,6 +80,8 @@ Describe Async.Promise.Hack
       redir END
       Assert Match(mes, '\CError detected while processing')
       Assert Match(mes, '\C_bar')
+      " Check called once
+      Assert NotMatch(mes, repeat('\C_bar.*', 2))
     End
   End
 

--- a/test/unit/Async/Promise/Hack.vimspec
+++ b/test/unit/Async/Promise/Hack.vimspec
@@ -15,7 +15,7 @@ Describe Async.Promise.Hack
         sleep 200m
       redir END
       Assert Match(mes, '\CError detected while processing')
-      Assert Match(mes, '\cerror from throw')
+      Assert Match(mes, '\Cerror from throw')
       " Check called just once
       Assert NotMatch(mes, repeat('\CError detected while processing.*', 2))
     End
@@ -24,9 +24,9 @@ Describe Async.Promise.Hack
         call Promise.new({resolve, reject -> [reject('reject from new'), 0][-1]})
         sleep 200m
       redir END
-      Assert Match(mes, '\creject from new')
+      Assert Match(mes, '\Creject from new')
       " Check called just once
-      Assert NotMatch(mes, repeat('\creject from new.*', 2))
+      Assert NotMatch(mes, repeat('\Creject from new.*', 2))
     End
     It not block .catch by user
       let handled_myself = 0
@@ -36,8 +36,18 @@ Describe Async.Promise.Hack
         sleep 200m
       redir END
       Assert NotMatch(mes, '\CError detected while processing')
-      Assert NotMatch(mes, '\cerror from throw')
+      Assert NotMatch(mes, '\Cerror from throw')
       Assert Equals(handled_myself, 1)
+    End
+    It helps the case the user failed to handle error by himself
+      redir => mes
+        call Promise.new({resolve, reject -> [execute("throw 'error for user'"), 0][-1]})
+              \.catch({-> [execute("throw 'failed to handle'")]})
+        sleep 200m
+      redir END
+      Assert NotMatch(mes, '\Cerror for user')
+      Assert Match(mes, '\CError detected while processing')
+      Assert Match(mes, '\Cfailed to handle')
     End
   End
 

--- a/test/unit/Async/Promise/Hack.vimspec
+++ b/test/unit/Async/Promise/Hack.vimspec
@@ -15,9 +15,32 @@ Describe Async.Promise.Hack
         sleep 200m
       redir END
       Assert Match(mes, '\CError detected while processing')
-      Assert Match(mes, '\Cerror from throw')
+      Assert Match(mes, '\C<Promise Uncaught Exception> error from throw')
       " Check called just once
       Assert NotMatch(mes, repeat('\CError detected while processing.*', 2))
+    End
+    Context echos object itself in special case
+      It is the case throwpoint is list
+        redir => mes
+          call Promise.new({resolve, reject -> reject({'throwpoint': [], 'exception': [], 'val': 1})})
+          sleep 200m
+        redir END
+        Assert Match(mes, '\C''val'': 1')
+        Assert Match(mes, '\C<Promise Uncaught> ')
+        " Check called just once
+        Assert NotMatch(mes, repeat('\CError detected while processing.*', 2))
+      End
+      It is the case throwpoint is string
+        redir => mes
+          call Promise.new({resolve, reject -> reject({'throwpoint': '', 'exception': [], 'val': 1})})
+          sleep 200m
+        redir END
+        Assert Match(mes, '\CError detected while processing')
+        Assert Match(mes, '\C''val'': 1')
+        Assert Match(mes, '\C<Promise Uncaught> ')
+        " Check called just once
+        Assert NotMatch(mes, repeat('\CError detected while processing.*', 2))
+      End
     End
     It echos rejected error
       redir => mes
@@ -26,7 +49,7 @@ Describe Async.Promise.Hack
       redir END
       Assert Match(mes, '\Creject from new')
       " Check called just once
-      Assert NotMatch(mes, repeat('\Creject from new.*', 2))
+      Assert NotMatch(mes, repeat('\C<Promise Uncaught> reject from new.*', 2))
     End
     It not block .catch by user
       let handled_myself = 0
@@ -62,6 +85,7 @@ Describe Async.Promise.Hack
         sleep 200m
       redir END
       Assert Match(mes, '\CError detected while processing')
+      Assert Match(mes, '\C<Promise Uncaught Exception> ')
       Assert Match(mes, '\C_bar')
       " Check called just once
       Assert NotMatch(mes, repeat('\CError detected while processing.*', 2))


### PR DESCRIPTION
newするとtimeoutミリ秒後に勝手に `.catch()` してくれる．(フォールバックとして)
大体いい感じに動くけど， `.then()` もhackしてもっと怠惰にしたい．
デフォルトでは無効で， `.set_debug(1)` をして有効化する．
vitalがextend的なものをおそらく用意していないので，現状，一部は `.call` 一個分のオーバーヘッドがつくことになる (そんな気にすることでもない)

